### PR TITLE
Upgrade to React 16

### DIFF
--- a/dist/formats/Code.js
+++ b/dist/formats/Code.js
@@ -14,10 +14,6 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _reactHighlight = require('react-highlight');
-
-var _reactHighlight2 = _interopRequireDefault(_reactHighlight);
-
 var _reactClipboard = require('react-clipboard.js');
 
 var _reactClipboard2 = _interopRequireDefault(_reactClipboard);
@@ -31,9 +27,6 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var DEFAULT_CLIPBOARD_ICON = 'fa-clipboard';
-var languageMap = {
-  curl: 'bash'
-};
 
 var Code = function (_Component) {
   _inherits(Code, _Component);
@@ -62,13 +55,9 @@ var Code = function (_Component) {
     value: function render() {
       var _props = this.props,
           example = _props.example,
-          language = _props.language,
           noclipboard = _props.noclipboard;
       var clipboardIcon = this.state.clipboardIcon;
 
-
-      var lowerCaseLanguage = language.toLowerCase();
-      var languageName = languageMap[lowerCaseLanguage] ? languageMap[lowerCaseLanguage] : lowerCaseLanguage;
 
       var clipboardButton = void 0;
       if (!noclipboard) {
@@ -83,13 +72,12 @@ var Code = function (_Component) {
         );
       }
 
-      // TODO: replace this Highlight component... It's tiny and terrible.
       return _react2.default.createElement(
         'div',
         { className: 'Code' },
         _react2.default.createElement(
-          _reactHighlight2.default,
-          { className: 'language-' + languageName + ' hljs' },
+          'code',
+          null,
           example
         ),
         clipboardButton
@@ -105,11 +93,9 @@ exports.default = Code;
 
 Code.propTypes = {
   example: _propTypes2.default.string,
-  language: _propTypes2.default.string,
   noclipboard: _propTypes2.default.bool
 };
 
 Code.defaultProps = {
-  noclipboard: false,
-  language: 'bash'
+  noclipboard: false
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "peerDependencies": {
-    "react": "^15.1.0"
+    "react": "^16.2"
   },
   "dependencies": {
     "brace": "^0.11.0",
@@ -21,8 +21,7 @@
     "prop-types": "^15.6.0",
     "react-ace": "^5.8.0",
     "react-clipboard.js": "^1.1.2",
-    "react-dom": "^15.1.0",
-    "react-highlight": "^0.10.0",
+    "react-dom": "^16.2",
     "react-router-dom": "^4.2.2",
     "react-select-plus": "^1.0.0-rc.5",
     "react-tabs": "^2.1.1",

--- a/scss/linode-components.scss
+++ b/scss/linode-components.scss
@@ -4,7 +4,6 @@
 @import 'utilities';
 
 @import '../node_modules/react-select-plus/dist/react-select-plus.min.css';
-@import '../node_modules/highlight.js/styles/tomorrow.css';
 
 @import 'components/index';
 

--- a/src/formats/Code.js
+++ b/src/formats/Code.js
@@ -1,13 +1,9 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Highlight from 'react-highlight';
 import ClipboardButton from 'react-clipboard.js';
 
 
 const DEFAULT_CLIPBOARD_ICON = 'fa-clipboard';
-const languageMap = {
-  curl: 'bash',
-};
 
 export default class Code extends Component {
   constructor() {
@@ -27,12 +23,8 @@ export default class Code extends Component {
   };
 
   render() {
-    const { example, language, noclipboard } = this.props;
+    const { example, noclipboard } = this.props;
     const { clipboardIcon } = this.state;
-
-    const lowerCaseLanguage = language.toLowerCase();
-    const languageName = languageMap[lowerCaseLanguage] ?
-      languageMap[lowerCaseLanguage] : lowerCaseLanguage;
 
     let clipboardButton;
     if (!noclipboard) {
@@ -47,12 +39,9 @@ export default class Code extends Component {
       );
     }
 
-    // TODO: replace this Highlight component... It's tiny and terrible.
     return (
       <div className="Code">
-        <Highlight className={`language-${languageName} hljs`}>
-          {example}
-        </Highlight>
+        <code>{example}</code>
         {clipboardButton}
       </div>
     );
@@ -61,11 +50,9 @@ export default class Code extends Component {
 
 Code.propTypes = {
   example: PropTypes.string,
-  language: PropTypes.string,
   noclipboard: PropTypes.bool,
 };
 
 Code.defaultProps = {
   noclipboard: false,
-  language: 'bash',
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,7 +1009,7 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-create-react-class@^15.5.2, create-react-class@^15.6.0:
+create-react-class@^15.5.2:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
   dependencies:
@@ -1590,10 +1590,6 @@ hawk@3.1.3, hawk@~3.1.3:
     cryptiles "2.x.x"
     hoek "2.x.x"
     sntp "1.x.x"
-
-highlight.js@^9.11.0:
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
 
 history@^4.7.2:
   version "4.7.2"
@@ -2201,7 +2197,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.8:
+prop-types@^15.5.0, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -2256,22 +2252,14 @@ react-clipboard.js@^1.1.2:
     clipboard "^1.6.1"
     prop-types "^15.5.0"
 
-react-dom@^15.1.0, react-dom@^15.5.4:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"
+react-dom@^16.2:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
   dependencies:
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
-
-react-highlight@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/react-highlight/-/react-highlight-0.10.0.tgz#d386f9dceab867dc0dcc2364153fb1cc7645d046"
-  dependencies:
-    highlight.js "^9.11.0"
-    react "^15.5.4"
-    react-dom "^15.5.4"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react-input-autosize@^1.1.3:
   version "1.1.5"
@@ -2325,16 +2313,6 @@ react-tooltip@^3.3.0:
   dependencies:
     classnames "^2.2.0"
     prop-types "^15.5.8"
-
-react@^15.5.4:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
-  dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
 
 readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
   version "2.3.3"


### PR DESCRIPTION
Upgrade to React 16

* Remove Highlight component (which depends on React 15) and replace with a `<code>` element for now. We were only using the Highlight component to highlight quoted strings for some shell code.